### PR TITLE
Updated Events.ts file to show date and location of next Tech Talks

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://www.dgotechub.org
+
+# Sitemaps
+Sitemap: https://www.dgotechub.org/sitemap.xml

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://www.dgotechub.org/pastevents</loc><lastmod>2025-04-26T20:53:49.217Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.dgotechub.org/tasks</loc><lastmod>2025-04-26T20:53:49.217Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.dgotechub.org/events</loc><lastmod>2025-04-26T20:53:49.217Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.dgotechub.org/community</loc><lastmod>2025-04-26T20:53:49.217Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.dgotechub.org/mural</loc><lastmod>2025-04-26T20:53:49.217Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.dgotechub.org</loc><lastmod>2025-04-26T20:53:49.217Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://www.dgotechub.org/sitemap-0.xml</loc></sitemap>
+</sitemapindex>

--- a/src/lib/Events.ts
+++ b/src/lib/Events.ts
@@ -28,10 +28,10 @@ const eventsData = {
     },
     {
       id: 2,
-      title: "Lighting Talks",
+      title: "Lightning Talks v3.0",
       image: "/techmetuup.jpg",
-      location: "Pendiente",
-      date: "Fecha por confirmar",
+      location: "Boscoffee. Independencia #334",
+      date: "30 de Abril, 2025",
       description:
         "Ideas rápidas, impacto inmediato. Únete a nuestras charlas tecnológicas.",
     },


### PR DESCRIPTION
On the Events.ts file updated the Lightning talks details to reflect the version of the event: v3.0, and also to show the location and date of the event. For the location, the address is shown too.

By the  way, robots and sitemaps files got updated after running the build command.