### PR TITLE
Update to PastEventCard component

### DIFF
--- a/src/app/(site)/community/page.tsx
+++ b/src/app/(site)/community/page.tsx
@@ -101,7 +101,7 @@ export default function CommunityPage() {
             asChild
           >
             <Link href={"https://discord.gg/G4RsQJwuP8"} target="_blank">
-              Unetenos ahora
+              Únete ahora
             </Link>
           </Button>
         </div>

--- a/src/components/site/pastevents/PastEventsCard.tsx
+++ b/src/components/site/pastevents/PastEventsCard.tsx
@@ -21,18 +21,19 @@ export default function PastEventsCard({
   date,
 }: PastEventsCardProps) {
   return (
-    <div className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow ">
+    <div className="h-full flex flex-col bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow">
       <div className="relative h-64">
         <Image src={image || ""} alt={title} fill className="object-cover" />
       </div>
-      <div className="p-4 flex flex-col gap-2">
-        <h3 className="font-bold text-xl">{title}</h3>
-        <p className="text-blue-600 text-sm">
-          {date} - {location}
-        </p>
-        <p className="text-gray-600 text-sm">{description}</p>
-      </div>
-      <div className="w-full flex justify-center mb-5">
+      <div className="p-4 flex-1 flex flex-col">
+        <div className="flex-1">
+          <h3 className="font-bold text-xl mb-2">{title}</h3>
+          <p className="text-blue-600 text-sm mb-2">
+            {date} - {location}
+          </p>
+          <p className="text-gray-600 text-sm">{description}</p>
+        </div>
+        <div className="w-full flex justify-center mt-4 pt-4">
         <Button
           asChild
           variant="outline"
@@ -46,6 +47,7 @@ export default function PastEventsCard({
             </Link>
           )}
         </Button>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
**Description:** 
It  changes the component to always show the card's button at the same position, regardless of the content of the card's content.

**Reason of change:** 
Quality of Life improvement to enhance the look and feel of the website.

**Screenshots:**
**Before:**
<img width="691" height="603" alt="Captura desde 2025-09-09 15-14-21" src="https://github.com/user-attachments/assets/2ad0a18e-2d36-491e-875c-f842d9803d85" />

**After:**
<img width="754" height="646" alt="Captura desde 2025-09-09 16-13-45" src="https://github.com/user-attachments/assets/fd851799-5fc2-4449-91f6-1fad666a49eb" />


**Another change made:**
Updated the Call To Action Button's text in the community page to have proper grammar. Changed from "Unetenos ahora" to "Únete ahora".

**Reason of change:** 
Quality of Life improvement to enhance the look and feel of the website.

**Screenshots**
**Before:**
<img width="1238" height="265" alt="Captura desde 2025-09-09 16-15-19" src="https://github.com/user-attachments/assets/b8383b56-a0bd-4487-9e80-29d5bbf71d3f" />

**After:**
<img width="1238" height="265" alt="Captura desde 2025-09-09 16-15-34" src="https://github.com/user-attachments/assets/c43a31d4-7f1e-48e5-92eb-ee9eea2bd497" />
